### PR TITLE
Removing EOF character

### DIFF
--- a/tasks/update-dependencies.js
+++ b/tasks/update-dependencies.js
@@ -7,7 +7,7 @@ if (!shell.which('git')) {
 }
 
 // Get the files that have been modified or null as a fallback
-var changedFiles = shell.exec('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').grep('yarn.lock').stdout || null;
+var changedFiles = shell.exec('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').grep('yarn.lock').stdout.trim() || null;
 
 // Execute the scripts if needed
 if(changedFiles !== null) {


### PR DESCRIPTION
Due to the EOF character generated by stdout the expression:

```javascript
shell.exec('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').grep('yarn.lock').stdout
```
isn't  _falsy_ so the expression:

```javascript
changedFiles !== null
```
Won't be _false_ in any case. :)