### PR TITLE
It's about dependencies

### DIFF
--- a/tasks/update-dependencies.js
+++ b/tasks/update-dependencies.js
@@ -17,6 +17,6 @@ if(changedFiles !== null) {
   shell.echo('\n---------------------------------------\n  The dependencies have been updated  \n---------------------------------------\n');
 }
 else {
-  shell.echo('\n-------------------------------\n  No files have been modified  \n-------------------------------\n');
+  shell.echo('\n-------------------------------\n  No dependencies have been modified  \n-------------------------------\n');
 }
 shell.exit(0);


### PR DESCRIPTION
This task looks for changes in dependencies not files, so it's more accurate to say "No dependencies have been modified" otherwise it can be confusing for the consumer.